### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish microfunctions-console
-      uses: elgohr/Publish-Docker-Github-Action@3.02
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: microfunctions/microfunctions-console
         username: ${{ secrets.LOGIN_DOCKER }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore